### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/lib/env-validation.ts
+++ b/lib/env-validation.ts
@@ -69,7 +69,7 @@ function generateDefaults(env: NodeJS.ProcessEnv) {
   
   if (!defaults.APP_URL) {
     defaults.APP_URL = defaults.NEXTAUTH_URL;
-    console.log(`🌐 Auto-generated APP_URL: ${defaults.APP_URL}`);
+    console.log('🌐 Auto-generated APP_URL');
   }
   
   return defaults;


### PR DESCRIPTION
Potential fix for [https://github.com/vorcigernix/pr_cat/security/code-scanning/2](https://github.com/vorcigernix/pr_cat/security/code-scanning/2)

Best fix: stop logging the raw environment-derived value and log only a non-sensitive status message.

In `lib/env-validation.ts`, update the log statement in the `if (!defaults.APP_URL)` block (line 72 area). Replace:

- `console.log(\`🌐 Auto-generated APP_URL: ${defaults.APP_URL}\`);`

with a constant message like:

- `console.log('🌐 Auto-generated APP_URL');`

This preserves functionality (APP_URL is still generated and assigned exactly the same) while removing the clear-text disclosure at the sink. No new methods/imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
